### PR TITLE
Fix missing peer lock initialization

### DIFF
--- a/src/peer.go
+++ b/src/peer.go
@@ -33,6 +33,7 @@ func NewPeer(maxPeers int) *Peer {
 	p := &Peer{
 		Hash:     sha1.New(),
 		MaxPeers: peers,
+		PeerLock: &sync.Mutex{},
 		Port:     "8888",
 		Peers:    make(map[string]net.Addr),
 		shutdown: false,


### PR DESCRIPTION
## Summary
- initialize the mutex used to guard the peer list in `NewPeer`
- verify building with module dependencies works

## Testing
- `go mod init p2p`
- `go mod tidy`
- `go build -o ./bin/p2p ./src`


------
https://chatgpt.com/codex/tasks/task_e_685717b6dd38832bbe33ae50d45614ee