### PR TITLE
Fix MaxPeers initialization

### DIFF
--- a/src/peer.go
+++ b/src/peer.go
@@ -32,7 +32,7 @@ type Peer struct {
 func NewPeer(maxPeers int) *Peer {
 	p := &Peer{
 		Hash:     sha1.New(),
-		MaxPeers: peers,
+		MaxPeers: maxPeers,
 		Port:     "8888",
 		Peers:    make(map[string]net.Addr),
 		shutdown: false,


### PR DESCRIPTION
## Summary
- use the `maxPeers` argument when constructing a new Peer

## Testing
- `go vet ./...` *(fails: directory prefix . does not contain main module)*
- `go build` *(fails: cannot find main module)*

------
https://chatgpt.com/codex/tasks/task_e_685717b746b0832b8e8b173446406c6a