### PR TITLE
Fix request parsing

### DIFF
--- a/src/handler.go
+++ b/src/handler.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"strings"
 )
 
 var MaxBuffer = 1024
@@ -17,9 +18,9 @@ type Handler struct {
 func (handler *Handler) HandleRequest(conn net.Conn) {
 	buffer := make([]byte, MaxBuffer)
 
-	_, err := conn.Read(buffer)
+	n, err := conn.Read(buffer)
 
-	request := string(buffer)
+	request := strings.TrimSpace(string(buffer[:n]))
 
 	if err != nil {
 		log.Printf("Error reading message from connection [%s]: %s\n", conn.RemoteAddr().String(), err.Error())


### PR DESCRIPTION
## Summary
- trim incoming connection request
- only parse the bytes read from the connection

## Testing
- `go build -o p2p ./src`

------
https://chatgpt.com/codex/tasks/task_e_685717b8838c832ba76dfb0b345b7c17